### PR TITLE
Remove /blog and gplus

### DIFF
--- a/templates/main.php
+++ b/templates/main.php
@@ -25,7 +25,6 @@
                 
                 <nav id="navigation">
                     <?php echo $searchField; ?>
-                    <a href="/blog">Blog</a>
                     <a href="#2" class="event-link">Events</a>
                     <a href="#3" class="who-link">Hvem er flug?</a>
                 </nav>
@@ -58,9 +57,6 @@
                         <div>
                             <a href="https://www.facebook.com/groups/flug.dk" target="_blank">
                                 <img src="/assets/fb_icon.png" alt="FB"/>
-                            </a>
-                            <a href="https://plus.google.com/communities/105454146240712904444" target="_blank">
-                                <img src="/assets/googleplus_icon.png" alt="GP"/>
                             </a>
                         </div>
                     </div>
@@ -120,16 +116,6 @@
                                 <li>
                                     <a href="https://www.facebook.com/groups/flug.dk" target="_blank">
                                         Facebook
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="https://plus.google.com/communities/105454146240712904444" target="_blank">
-                                        <img height="30" src="/assets/googleplus_icon.png" alt="GP"/>
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="https://plus.google.com/communities/105454146240712904444" target="_blank">
-                                        Google+
                                     </a>
                                 </li>
                             </ul>

--- a/templates/main.php
+++ b/templates/main.php
@@ -98,8 +98,6 @@
                             <ul id="site-links" class="list-line">
                                 <li><a class="home-link" href="#1">flug.dk</a></li>
                                 <li>/</li>
-                                <li><a href="/blog">Blog</a></li>
-                                <li>/</li>
                                 <li><a class="event-link" href="#2">Events</a></li>
                                 <li>/</li>
                                 <li><a class="who-link" href="#3">Hvem er flug?</a></li>


### PR DESCRIPTION
Remove references to /blog and the Google+ profile in `templates/main.php`.

Have not touched the `templates/blog.php` and `templates/blogpost.php` files, but they seem ripe for deletion.