### PR TITLE
Added bylaws as Markdown, and html

### DIFF
--- a/bylaws.html
+++ b/bylaws.html
@@ -1,0 +1,350 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>Vedtægter for FLUG</title>
+  <style>
+    html {
+      color: #1a1a1a;
+      background-color: #fdfdfd;
+    }
+    body {
+      margin: 0 auto;
+      max-width: 36em;
+      padding-left: 50px;
+      padding-right: 50px;
+      padding-top: 50px;
+      padding-bottom: 50px;
+      hyphens: auto;
+      overflow-wrap: break-word;
+      text-rendering: optimizeLegibility;
+      font-kerning: normal;
+    }
+    @media (max-width: 600px) {
+      body {
+        font-size: 0.9em;
+        padding: 12px;
+      }
+      h1 {
+        font-size: 1.8em;
+      }
+    }
+    @media print {
+      html {
+        background-color: white;
+      }
+      body {
+        background-color: transparent;
+        color: black;
+        font-size: 12pt;
+      }
+      p, h2, h3 {
+        orphans: 3;
+        widows: 3;
+      }
+      h2, h3, h4 {
+        page-break-after: avoid;
+      }
+    }
+    p {
+      margin: 1em 0;
+    }
+    a {
+      color: #1a1a1a;
+    }
+    a:visited {
+      color: #1a1a1a;
+    }
+    img {
+      max-width: 100%;
+    }
+    h1, h2, h3, h4, h5, h6 {
+      margin-top: 1.4em;
+    }
+    h5, h6 {
+      font-size: 1em;
+      font-style: italic;
+    }
+    h6 {
+      font-weight: normal;
+    }
+    ol, ul {
+      padding-left: 1.7em;
+      margin-top: 1em;
+    }
+    li > ol, li > ul {
+      margin-top: 0;
+    }
+    blockquote {
+      margin: 1em 0 1em 1.7em;
+      padding-left: 1em;
+      border-left: 2px solid #e6e6e6;
+      color: #606060;
+    }
+    code {
+      font-family: Menlo, Monaco, Consolas, 'Lucida Console', monospace;
+      font-size: 85%;
+      margin: 0;
+      hyphens: manual;
+    }
+    pre {
+      margin: 1em 0;
+      overflow: auto;
+    }
+    pre code {
+      padding: 0;
+      overflow: visible;
+      overflow-wrap: normal;
+    }
+    .sourceCode {
+     background-color: transparent;
+     overflow: visible;
+    }
+    hr {
+      background-color: #1a1a1a;
+      border: none;
+      height: 1px;
+      margin: 1em 0;
+    }
+    table {
+      margin: 1em 0;
+      border-collapse: collapse;
+      width: 100%;
+      overflow-x: auto;
+      display: block;
+      font-variant-numeric: lining-nums tabular-nums;
+    }
+    table caption {
+      margin-bottom: 0.75em;
+    }
+    tbody {
+      margin-top: 0.5em;
+      border-top: 1px solid #1a1a1a;
+      border-bottom: 1px solid #1a1a1a;
+    }
+    th {
+      border-top: 1px solid #1a1a1a;
+      padding: 0.25em 0.5em 0.25em 0.5em;
+    }
+    td {
+      padding: 0.125em 0.5em 0.25em 0.5em;
+    }
+    header {
+      margin-bottom: 4em;
+      text-align: center;
+    }
+    #TOC li {
+      list-style: none;
+    }
+    #TOC ul {
+      padding-left: 1.3em;
+    }
+    #TOC > ul {
+      padding-left: 0;
+    }
+    #TOC a:not(:hover) {
+      text-decoration: none;
+    }
+    code{white-space: pre-wrap;}
+    span.smallcaps{font-variant: small-caps;}
+    div.columns{display: flex; gap: min(4vw, 1.5em);}
+    div.column{flex: auto; overflow-x: auto;}
+    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+    /* The extra [class] is a hack that increases specificity enough to
+       override a similar rule in reveal.js */
+    ul.task-list[class]{list-style: none;}
+    ul.task-list li input[type="checkbox"] {
+      font-size: inherit;
+      width: 0.8em;
+      margin: 0 0.8em 0.2em -1.6em;
+      vertical-align: middle;
+    }
+    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  </style>
+</head>
+<body>
+<h1 id="vedtægter-for-foreningen-flug---fyns-linux-user-group">Vedtægter
+for foreningen FLUG - Fyns Linux User Group</h1>
+<h2 id="navn-og-hjemsted">Navn og hjemsted</h2>
+<p>§1. stk. 1</p>
+<p>Foreningens navn er FLUG - Fyns Linux User Group.</p>
+<p>§1. stk. 2</p>
+<p>Foreningens hjemsted er Odense Universitet.</p>
+<p>§1. stk. 3</p>
+<p>Foreningens postadresse er:</p>
+<p>FLUG - Fyns Linux User Group</p>
+<p>c/o</p>
+<p>Odense</p>
+<h2 id="formål">Formål</h2>
+<p>§2. stk. 1</p>
+<p>Det er foreningens formål at skabe arrangementer for Linux brugere på
+Fyn, samt sekundært at udbrede kendskabet til styresystemet Linux på Fyn
+samt GNU værktøjer og ideologier.</p>
+<h2 id="medlemmer">Medlemmer</h2>
+<p>§3. stk. 1</p>
+<p>Som medlemmer optages personer med interesse i større kendskab til
+Linux.</p>
+<p>§3. stk. 2</p>
+<p>Indmeldelse sker ved tilmelding til mailing listen
+flug-announce@flug.dk</p>
+<p>§3. stk. 3</p>
+<p>Medlemmer betaler egne udgifter i forbindelse med arrangementer,
+arrangeret af foreningen.</p>
+<p>§3. stk. 4</p>
+<p>Udmeldelse sker ved afmelding af mailing listen
+flug-announce@flug.dk</p>
+<h2 id="generalforsamlingen">Generalforsamlingen</h2>
+<p>§4. stk. 1</p>
+<p>Foreningens øverste myndighed er generalforsamlingen samt
+afstemninger på mailing listen flug-stem (Se §10).</p>
+<p>§4. stk. 2</p>
+<p>Generalforsamlingen mødes ordinært en gang årligt, første torsdag i
+september.</p>
+<p>§4. stk. 3</p>
+<p>Generalforsamlingen består af foreningens medlemmer. Ikke-medlemmer
+har ikke ret til at overvære generalforsamlingen.</p>
+<p>§4. stk. 4</p>
+<p>Bestyrelsen kan indbyde gæster til at overvære generalforsamlingen.
+Indbudte gæster er dog uden stemmeret.</p>
+<p>§4. stk. 5</p>
+<p>Generalforsamlingen vælger 1 formand, 2 menige bestyrelsesmedlemmer
+samt 2 supplanter. Kan der på generalforsamlingen ikke opstilles 3
+kandidater, vælger man det, på generalforsamlingen, antal mulige
+medlemmer til bestyrelsen. De, på generalforsamlingen valgte
+bestyrelsesmedlemmer, har efter den ordinære generalforsamling ret til
+at optage fuldgyldige bestyrelsesmedlemmer op til rammen på 3 personer.
+Heraf følger, at der ikke findes suppleanter.</p>
+<p>§4. stk.6</p>
+<p>Generalforsamlingens dato bekendtgøres på foreningens mailing liste
+flug-announce@flug.dk, mindst en uge før afholdelse.</p>
+<p>§4. stk. 7</p>
+<p>Generalforsamlingens dagsorden skal mindst indeholde følgende
+punkter:</p>
+<ul>
+<li>Åbning af generalforsamling af formand.</li>
+<li>Behandling af indkommende forslag.</li>
+<li>Valg af 3 Bestyrelsesmedlemmer.</li>
+<li>Eventuelt.</li>
+</ul>
+<p>§4. stk. 8</p>
+<p>Ved personvalg gælder følgende regler:</p>
+<ul>
+<li>Personvalg afgøres ved absolut flertal, evt. i flere
+afstemninger.</li>
+<li>Afstemninger sker ved håndsoprækning. Forlanger forsamlingen en
+skriftlig afstemning, skal dette efterkommes, dersom mindst 1/4 af
+mødets deltagere anmoder derom.</li>
+</ul>
+<p>§4. stk. 10</p>
+<p>Ved andre afstamninger gælder følgende særlige regler:</p>
+<ul>
+<li>Forslag om vedtægtsændringer vedtages med kvalificeret flertal på
+mindst 2/3 af de afgivne stemmer.</li>
+</ul>
+<p>§4. stk. 11</p>
+<p>Forslag om foreningens opløsning kan kun behandles på en
+ekstraordinær generalforsamling, hvor mindst halvdelen af medlemmerne er
+til stede på afstemningstidspunktet, og hvor forslaget om opløsning
+vedtages med et kvalificeret flertal på mindst 2/3 af de afgivne
+stemmer. Er færre end halvdelen af medlemmerne til stede på
+afstemningstidspunktet, indkaldes til ny ekstraordinær
+generalforsamling, hvor forslaget om opløsning kan vedtages med absolut
+flertal af de afgivne stemmer uanset antallet af tilstedeværende
+medlemmer.</p>
+<p>§4. stk. 12</p>
+<p>Ekstraordinær generalforsamling kan indkaldes af bestyrelsen og skal
+indkaldes, hvis mindst 10 procent af medlemerne overfor bestyrelsen
+fremsætter begrundet anmodning herom. Generalforsamlingen skal afholdes
+senest fire uger efter, at anmodningen er modtaget.</p>
+<p>§4. stk. 13</p>
+<p>Fristen for indkaldelse af ekstraordinær generalforsamling er en
+uge.</p>
+<h2 id="bestyrelsen">Bestyrelsen</h2>
+<p>§5. stk. 1</p>
+<p>Bestyrelsen der består af 3 medlemmer, er foreningens højeste
+myndighed mellem generalforsamlingerne.</p>
+<p>§5. stk. 2</p>
+<p>Bestyrelsen er beslutningsdygtig, når mindst 2/3 er
+tilstedeværende.</p>
+<p>§5. stk. 3</p>
+<p>Bestyrelsen mødes efter behov</p>
+<p>§5. stk. 4</p>
+<p>Bestyrelsen leder foreningen i overensstemmelse med nærværende
+vedtægter og beslutninger. Den har med disse begrænsninger myndighed til
+at handle på foreningens vegne, og i foreningens interesse. Bestyrelsen
+er ansvarlig for foreningens økonomi, dog uden at hæfte personligt, for
+eventuel gæld.</p>
+<p>§5. stk. 5</p>
+<p>Bestyrelsen kan nedsætte udvalg. I så fald skal bestyrelsen udarbejde
+et kommissorium for udvalgets arbejde og tage stilling til
+udvalgsarbejdets tidsmæssige udstrækning og økonomi.</p>
+<p>§5. stk. 6</p>
+<p>Personvalg afgøres ved absolut flertal, eventuelt i flere
+valgrunder.</p>
+<p>§5. stk. 7</p>
+<p>Ekstraordinært bestyrelsesmøde indkaldes hvis et bestyrelsesmedlem
+fremsætter begrundet anmodning herom til formanden. Ekstraordinært
+bestyrelsesmøde skal afholdes senest en uge efter, at anmodningen herom
+er modtaget af formanden.</p>
+<p>§5. stk. 8</p>
+<p>foreningen tegnes af hel bestyrelsen</p>
+<p>§5. stk. 9</p>
+<p>udmeldelse af bestyrelsen foregår ved at sende en email til
+flug-announce</p>
+<h2 id="udvalg">Udvalg</h2>
+<p>§6. stk. 1</p>
+<p>Udvalgene skal behandle og komme med forslag om emner under
+udvalgenes sagsområder i overensstemmelse med deres kommissorier.</p>
+<h2 id="økonomi">Økonomi</h2>
+<p>§7. stk. 1</p>
+<p>Foreningen er non-profit, dog kan penge opkræves ved specielle
+arrangementer til dækning af udgifter i forbindelse ved
+arrangementet.</p>
+<h2 id="opløsning-af-foreningen">Opløsning af foreningen</h2>
+<p>§8. stk. 1</p>
+<p>Beslutning om opløsning af foreningen kan kun træffes på en
+ekstraordinær generalforsamling, der er indkaldt med dette punkt på
+dagsordenen.</p>
+<p>§8. stk. 2</p>
+<p>Denne ekstraordinære generalforsamling er kun beslutningsdygtig, hvis
+mere end halvdelen af alle medlemmer er til stede på
+afstemningstidspunktet.</p>
+<p>§8. stk. 3</p>
+<p>Et forslag om opløsning kan kun vedtages med kvalificeret flertal på
+mindst 2/3 af de afgivne stemmer.</p>
+<p>§8. stk. 4</p>
+<p>Er færre end halvdelen af medlemmerne til stede på
+afstemningstidspunktet, indkaldes til ny ekstraordinær
+generalforsamling, hvor forslaget om opløsning kan vedtages med absolut
+flertal af de afgivne stemmer uanset antallet af tilstedeværende
+medlemmer.</p>
+<p>§8. stk 5</p>
+<p>Ved opløsning af foreningen tilfalder evt. aktiver til “The Free
+software foundation”.</p>
+<h2 id="datering">Datering</h2>
+<p>§9. stk. 1</p>
+<p>Ovenstående lovforslag er vedtaget på FLUG’s stiftende
+generalforsamling den 2/9/1999. §10 blev tilføjet ved en ekstraordinær
+generalforsamling d. 25/11-99</p>
+<h2 id="afstemninger-på-mailingadressen-flug-stem">Afstemninger på
+mailingadressen flug-stem</h2>
+<p>§10. stk 1</p>
+<p>Ud over afstemninger på generalforsamlingen kan vigtige beslutninger,
+herunder vedtægtsændringer, tages ved en afstemning på adressen
+flug-stem@flug.dk.</p>
+<p>§10. stk 2</p>
+<p>Afstemningen skal løbe over en uge, og skal annonceres på
+flug-announce</p>
+<p>§10. stk 3</p>
+<p>Kun folk der er medlem ved afstemningens start må stemme.</p>
+<p>§10. stk 4</p>
+<p>Afstemningen foregår på følgende måde: Medlemmet sender en stemme til
+adressen flug-stem@flug.dk. I kroppen af denne mail skriver han hvad han
+stemmer, samt et alias som kun han kender.</p>
+<p>Ved afslutning af afstemningen sendes svaret på flug-announce, samt
+en liste over hvem der har stemt (dvs folks rigtige email adresser),
+samt en liste over hvad hvilke aliases har stemt.</p>
+</body>
+</html>

--- a/bylaws.md
+++ b/bylaws.md
@@ -1,0 +1,203 @@
+# Vedtægter for foreningen FLUG - Fyns Linux User Group
+
+## Navn og hjemsted
+
+§1. stk. 1
+
+Foreningens navn er FLUG - Fyns Linux User Group.
+
+§1. stk. 2
+
+Foreningens hjemsted er Odense Universitet.
+
+§1. stk. 3
+
+Foreningens postadresse er:
+
+FLUG - Fyns Linux User Group
+
+c/o
+
+Odense
+
+## Formål
+
+§2. stk. 1
+
+Det er foreningens formål at skabe arrangementer for Linux brugere på Fyn, samt sekundært at udbrede kendskabet til styresystemet Linux på Fyn samt GNU værktøjer og ideologier.
+
+## Medlemmer
+
+§3. stk. 1
+
+Som medlemmer optages personer med interesse i større kendskab til Linux.
+
+§3. stk. 2
+
+Indmeldelse sker ved tilmelding til mailing listen flug-announce@flug.dk
+
+§3. stk. 3
+
+Medlemmer betaler egne udgifter i forbindelse med arrangementer, arrangeret af foreningen.
+
+§3. stk. 4
+
+Udmeldelse sker ved afmelding af mailing listen flug-announce@flug.dk
+
+## Generalforsamlingen
+
+§4. stk. 1
+
+Foreningens øverste myndighed er generalforsamlingen samt afstemninger på mailing listen flug-stem (Se §10).
+
+§4. stk. 2
+
+Generalforsamlingen mødes ordinært en gang årligt, første torsdag i september.
+
+§4. stk. 3
+
+Generalforsamlingen består af foreningens medlemmer. Ikke-medlemmer har ikke ret til at overvære generalforsamlingen.
+
+§4. stk. 4
+
+Bestyrelsen kan indbyde gæster til at overvære generalforsamlingen. Indbudte gæster er dog uden stemmeret.
+
+§4. stk. 5
+
+Generalforsamlingen vælger 1 formand, 2 menige bestyrelsesmedlemmer samt 2 supplanter. Kan der på generalforsamlingen ikke opstilles 3 kandidater, vælger man det, på generalforsamlingen, antal mulige medlemmer til bestyrelsen. De, på generalforsamlingen valgte bestyrelsesmedlemmer, har efter den ordinære generalforsamling ret til at optage fuldgyldige bestyrelsesmedlemmer op til rammen på 3 personer. Heraf følger, at der ikke findes suppleanter.
+
+§4. stk.6
+
+Generalforsamlingens dato bekendtgøres på foreningens mailing liste flug-announce@flug.dk, mindst en uge før afholdelse.
+
+§4. stk. 7
+
+Generalforsamlingens dagsorden skal mindst indeholde følgende punkter:
+
+* Åbning af generalforsamling af formand.
+* Behandling af indkommende forslag.
+* Valg af 3 Bestyrelsesmedlemmer.
+* Eventuelt.
+
+§4. stk. 8
+
+Ved personvalg gælder følgende regler:
+
+* Personvalg afgøres ved absolut flertal, evt. i flere afstemninger.
+* Afstemninger sker ved håndsoprækning. Forlanger forsamlingen en skriftlig afstemning, skal dette efterkommes, dersom mindst 1/4 af mødets deltagere anmoder derom.
+
+§4. stk. 10
+
+Ved andre afstamninger gælder følgende særlige regler:
+
+* Forslag om vedtægtsændringer vedtages med kvalificeret flertal på mindst 2/3 af de afgivne stemmer.
+
+§4. stk. 11
+
+Forslag om foreningens opløsning kan kun behandles på en ekstraordinær generalforsamling, hvor mindst halvdelen af medlemmerne er til stede på afstemningstidspunktet, og hvor forslaget om opløsning vedtages med et kvalificeret flertal på mindst 2/3 af de afgivne stemmer. Er færre end halvdelen af medlemmerne til stede på afstemningstidspunktet, indkaldes til ny ekstraordinær generalforsamling, hvor forslaget om opløsning kan vedtages med absolut flertal af de afgivne stemmer uanset antallet af tilstedeværende medlemmer.
+
+§4. stk. 12
+
+Ekstraordinær generalforsamling kan indkaldes af bestyrelsen og skal indkaldes, hvis mindst 10 procent af medlemerne overfor bestyrelsen fremsætter begrundet anmodning herom. Generalforsamlingen skal afholdes senest fire uger efter, at anmodningen er modtaget.
+
+§4. stk. 13
+
+Fristen for indkaldelse af ekstraordinær generalforsamling er en uge.
+
+## Bestyrelsen
+
+§5. stk. 1
+
+Bestyrelsen der består af 3 medlemmer, er foreningens højeste myndighed mellem generalforsamlingerne.
+
+§5. stk. 2
+
+Bestyrelsen er beslutningsdygtig, når mindst 2/3 er tilstedeværende.
+
+§5. stk. 3
+
+Bestyrelsen mødes efter behov
+
+§5. stk. 4
+
+Bestyrelsen leder foreningen i overensstemmelse med nærværende vedtægter og beslutninger. Den har med disse begrænsninger myndighed til at handle på foreningens vegne, og i foreningens interesse. Bestyrelsen er ansvarlig for foreningens økonomi, dog uden at hæfte personligt, for eventuel gæld.
+
+§5. stk. 5
+
+Bestyrelsen kan nedsætte udvalg. I så fald skal bestyrelsen udarbejde et kommissorium for udvalgets arbejde og tage stilling til udvalgsarbejdets tidsmæssige udstrækning og økonomi.
+
+§5. stk. 6
+
+Personvalg afgøres ved absolut flertal, eventuelt i flere valgrunder.
+
+§5. stk. 7
+
+Ekstraordinært bestyrelsesmøde indkaldes hvis et bestyrelsesmedlem fremsætter begrundet anmodning herom til formanden. Ekstraordinært bestyrelsesmøde skal afholdes senest en uge efter, at anmodningen herom er modtaget af formanden.
+
+§5. stk. 8
+
+foreningen tegnes af hel bestyrelsen
+
+§5. stk. 9
+
+udmeldelse af bestyrelsen foregår ved at sende en email til flug-announce
+
+## Udvalg
+
+§6. stk. 1
+
+Udvalgene skal behandle og komme med forslag om emner under udvalgenes sagsområder i overensstemmelse med deres kommissorier.
+
+## Økonomi
+
+§7. stk. 1
+
+Foreningen er non-profit, dog kan penge opkræves ved specielle arrangementer til dækning af udgifter i forbindelse ved arrangementet.
+
+## Opløsning af foreningen
+
+§8. stk. 1
+
+Beslutning om opløsning af foreningen kan kun træffes på en ekstraordinær generalforsamling, der er indkaldt med dette punkt på dagsordenen.
+
+§8. stk. 2
+
+Denne ekstraordinære generalforsamling er kun beslutningsdygtig, hvis mere end halvdelen af alle medlemmer er til stede på afstemningstidspunktet.
+
+§8. stk. 3
+
+Et forslag om opløsning kan kun vedtages med kvalificeret flertal på mindst 2/3 af de afgivne stemmer.
+
+§8. stk. 4
+
+Er færre end halvdelen af medlemmerne til stede på afstemningstidspunktet, indkaldes til ny ekstraordinær generalforsamling, hvor forslaget om opløsning kan vedtages med absolut flertal af de afgivne stemmer uanset antallet af tilstedeværende medlemmer.
+
+§8. stk 5
+
+Ved opløsning af foreningen tilfalder evt. aktiver til "The Free software foundation".
+
+## Datering
+
+§9. stk. 1
+
+Ovenstående lovforslag er vedtaget på FLUG's stiftende generalforsamling den 2/9/1999. §10 blev tilføjet ved en ekstraordinær generalforsamling d. 25/11-99
+
+## Afstemninger på mailingadressen flug-stem
+
+§10. stk 1
+
+Ud over afstemninger på generalforsamlingen kan vigtige beslutninger, herunder vedtægtsændringer, tages ved en afstemning på adressen flug-stem@flug.dk.
+
+§10. stk 2
+
+Afstemningen skal løbe over en uge, og skal annonceres på flug-announce
+
+§10. stk 3
+
+Kun folk der er medlem ved afstemningens start må stemme.
+
+§10. stk 4
+
+Afstemningen foregår på følgende måde: Medlemmet sender en stemme til adressen flug-stem@flug.dk. I kroppen af denne mail skriver han hvad han stemmer, samt et alias som kun han kender.
+
+Ved afslutning af afstemningen sendes svaret på flug-announce, samt en liste over hvem der har stemt (dvs folks rigtige email adresser), samt en liste over hvad hvilke aliases har stemt.


### PR DESCRIPTION
Added bylaws (with name and address of former chairman removed) as Markdown.

Added html version, generated with
`pandoc bylaws.md -s --metadata title="Vedtægter for FLUG" -V title:"" -o bylaws.html`

Not added links to the bylaws from the frontpage, so currently, only way to access them is if you know the url. But it seems more easy to be able to access them here, than at their previous location. 

