### PR TITLE
ci(Docker): Remove CentOS image with php:7.2-apache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,9 @@
-FROM docker.io/centos/httpd
-MAINTAINER Joe Sørensen <joe.sorensen@flug.dk>
+FROM php:7.2-apache
 
-RUN yum -y install git
-RUN yum -y install php
-RUN git clone https://github.com/JoeX2/flug.dk.git /var/www/html
+COPY httpd/conf.d/flug.dk.conf /etc/apache2/sites-available/
+COPY . /var/www/html/
 
-ADD httpd/conf.d/flug.dk.conf /etc/httpd/conf.d/
+RUN a2enmod rewrite
+RUN a2ensite flug.dk
 
-RUN yum -y update
-RUN rm -rf /var/cache/yum && yum clean all
-
-RUN ln -sf /dev/stdout /var/log/httpd/access_log && ln -sf /dev/stderr /var/log/httpd/error_log
-
+RUN ln -sf /dev/stdout /var/log/apache2/access_log && ln -sf /dev/stderr /var/log/apache2/error_log


### PR DESCRIPTION
Remove references to /blog and the Google+ profile in templates/main.php.

Have not touched the templates/blog.php and templates/blogpost.php files, but they seem ripe for deletion.
